### PR TITLE
Update standalone config to make it consistent with PR#1561

### DIFF
--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -1,7 +1,7 @@
 {
   "ignoreGlobList": ["about-us/**", "**index.html"],
   "formats": ["html", "css"],
-  "ignoreCommitList": ["", "67890def"],
+  "ignoreCommitsList": ["", "67890def"],
   "authors":
   [
     {


### PR DESCRIPTION
[PR#1561](https://github.com/reposense/RepoSense/pull/1561) parses ```ignoreCommitsList``` instead of ```ignoreCommitList``` in Standalone Config.