### PR TITLE
Add 3rd test file for testing annotated author override

### DIFF
--- a/analyzeAuthorshipTest3.java
+++ b/analyzeAuthorshipTest3.java
@@ -1,0 +1,9 @@
+// @author myteo
+This line is commited by SkyBlaise but attributed to myteo.
+myteo should get partial credit.
+// @@author
+
+// @author SkyBlaise
+This line is commited by SkyBlaise and attributed to SkyBlaise.
+SkyBlaise should get full credit.
+// @@author


### PR DESCRIPTION
Currently [#2060](https://github.com/reposense/RepoSense/pull/2060) is failing codecov/patch because the new codes are not covered by test cases. The file added is used to test the behavior of overriding the assigned credit information on the blamed author by the annotated author.